### PR TITLE
update typo in converts

### DIFF
--- a/spec/01_input_to_index_spec.rb
+++ b/spec/01_input_to_index_spec.rb
@@ -2,7 +2,7 @@ require_relative "../lib/move.rb"
 
 describe '#input_to_index' do
 
-  it 'convervets a user_input to an integer' do
+  it 'converts a user_input to an integer' do
     user_input = "1"
 
     expect(input_to_index(user_input)).to be_a(Integer)


### PR DESCRIPTION
Line 5 converts was spelled incorrectly. This request corrects that.
